### PR TITLE
Fix mal.commands.login

### DIFF
--- a/mal/__init__.py
+++ b/mal/__init__.py
@@ -7,7 +7,7 @@
 #
 #
 
-__version__ = '0.1.5'
+__version__ = '0.2'
 __author__ = 'Manoel Vilela'
 __email__ = 'manoel_vilela@engineer.com'
 __url__ = 'https://github.com/ryukinix/mal'

--- a/mal/commands.py
+++ b/mal/commands.py
@@ -12,6 +12,7 @@ import sys
 
 # self-package
 from mal import core
+from mal import login as _login
 
 def search(mal, args):
     core.find(mal, vars(args)['anime-regex'].lower())
@@ -26,7 +27,7 @@ def decrease(mal, args):
 
 
 def login(mal, args):
-    login.create_credentials()
+    _login.create_credentials()
     sys.exit(0)
 
 


### PR DESCRIPTION
We forgot to import module login and I need to rename login module
to _login to not conflict with function login of mal.commands.
