### PR TITLE
cli: replace `episodes` to `-n` and `anime-regex` to `anime_regex`

### DIFF
--- a/mal/cli.py
+++ b/mal/cli.py
@@ -31,7 +31,7 @@ def create_parser():
     # Parser for "search" command
     parser_search = subparsers.add_parser('search',
                                           help='search an anime')
-    parser_search.add_argument('anime-regex',
+    parser_search.add_argument('anime_regex',
                                help='regex pattern to match anime titles')
     parser_search.set_defaults(func=commands.search)
 
@@ -39,9 +39,9 @@ def create_parser():
     parser_increase = subparsers.add_parser('increase',
                                             help="increase anime's watched episodes by one",
                                             aliases=['inc'])
-    parser_increase.add_argument('anime-regex',
+    parser_increase.add_argument('anime_regex',
                                  help='regex pattern to match anime titles')
-    parser_increase.add_argument('episodes', type=int, default=1,
+    parser_increase.add_argument('-n', type=int, default=1,
                                  help='number of episodes to increase')
     parser_increase.set_defaults(func=commands.increase)
 
@@ -49,9 +49,9 @@ def create_parser():
     parser_decrease = subparsers.add_parser('decrease',
                                             help="decrease anime's watched episodes by one",
                                             aliases=['dec'])
-    parser_decrease.add_argument('anime-regex', 
+    parser_decrease.add_argument('anime_regex',
                                   help='regex pattern to match anime titles')
-    parser_decrease.add_argument('episodes', type=int, default=1,
+    parser_decrease.add_argument('-n', type=int, default=1,
                                  help='number of episodes to decrease')
 
     parser_decrease.set_defaults(func=commands.decrease)

--- a/mal/commands.py
+++ b/mal/commands.py
@@ -20,15 +20,15 @@ from mal import login as _login
 
 def search(mal, args):
     """Search MAL (not just the user) anime database."""
-    core.find(mal, vars(args)['anime-regex'].lower())
+    core.find(mal, args.anime_regex.lower())
 
 
 def increase(mal, args):
-    core.progress_update(mal, vars(args)['anime-regex'].lower(), args.episodes)
+    core.progress_update(mal, args.anime_regex.lower(), args.n)
 
 
 def decrease(mal, args):
-    core.progress_update(mal, vars(args)['anime-regex'].lower(), -args.episodes)
+    core.progress_update(mal, args.anime_regex.lower(), -args.n)
 
 
 def login(mal, args):


### PR DESCRIPTION
* I replaced the episodes arguments to `-n` to cover the old behavior
like `mal inc anime-regex` with default=1. Arguments without prefixed
hyphens cannot be used as optional, they will be mandatory.

* For anime-regex => anime_regex I changed on inc, dec and search subparser
and commands. I just do that to simplify the usage of the args using
ArgParse, as Python cannot create identifiers using Lisp-case
(first-second-third), we need access them using vars(args)['anime-regex'].
This is really ugly.

Just refactoring some things after merged PR #26, commented on #16.