### PR TITLE
Rollback 'episode' argument and add nargs='?'

### DIFF
--- a/mal/__init__.py
+++ b/mal/__init__.py
@@ -7,7 +7,7 @@
 #
 #
 
-__version__ = '0.2.2'
+__version__ = '0.2.3'
 __author__ = 'Manoel Vilela'
 __email__ = 'manoel_vilela@engineer.com'
 __url__ = 'https://github.com/ryukinix/mal'

--- a/mal/cli.py
+++ b/mal/cli.py
@@ -41,7 +41,10 @@ def create_parser():
                                             aliases=['inc'])
     parser_increase.add_argument('anime_regex',
                                  help='regex pattern to match anime titles')
-    parser_increase.add_argument('-n', type=int, default=1,
+    parser_increase.add_argument('episodes',
+                                 nargs='?',
+                                 type=int,
+                                 default=1,
                                  help='number of episodes to increase')
     parser_increase.set_defaults(func=commands.increase)
 
@@ -51,7 +54,10 @@ def create_parser():
                                             aliases=['dec'])
     parser_decrease.add_argument('anime_regex',
                                   help='regex pattern to match anime titles')
-    parser_decrease.add_argument('-n', type=int, default=1,
+    parser_decrease.add_argument('episodes',
+                                 nargs='?',
+                                 type=int,
+                                 default=1,
                                  help='number of episodes to decrease')
 
     parser_decrease.set_defaults(func=commands.decrease)

--- a/mal/commands.py
+++ b/mal/commands.py
@@ -24,11 +24,11 @@ def search(mal, args):
 
 
 def increase(mal, args):
-    core.progress_update(mal, args.anime_regex.lower(), args.n)
+    core.progress_update(mal, args.anime_regex.lower(), args.episodes)
 
 
 def decrease(mal, args):
-    core.progress_update(mal, args.anime_regex.lower(), -args.n)
+    core.progress_update(mal, args.anime_regex.lower(), -args.episodes)
 
 
 def login(mal, args):


### PR DESCRIPTION
This avoid the problem to use prefix `-n` notation and that two usages
will be allowed:

- mal inc anime-regex
- mal inc anime-regex episodes

As well for dec too.