### PR TITLE
Extend info for list command

### DIFF
--- a/mal/api.py
+++ b/mal/api.py
@@ -84,7 +84,7 @@ class MyAnimeList(object):
 
     @checked_connection
     @animated('preparing animes')
-    def list(self, status='all', type='anime'):
+    def list(self, status='all', type='anime', extra=False):
         username = self.username
 
         payload = dict(u=username, status=status, type=type)
@@ -116,13 +116,22 @@ class MyAnimeList(object):
                 if result[entry_id]['rewatching']:
                     result[entry_id]['status_name'] = 'rewatching'
 
+                # if extra information was requested (via --extend cmd line flag) add it to the result
+                if extra:
+                    extra_info = {
+                        'start_date': entry['my_start_date'],
+                        'finish_date': entry['my_finish_date'],
+                        'tags': entry['my_tags']
+                    }
+                    result[entry_id].update(extra_info)
+
         return result
 
     @checked_regex
     @animated('matching animes')
-    def find(self, regex, status='all'):
+    def find(self, regex, status='all', extra=False):
         result = []
-        for value in self.list(status).values():
+        for value in self.list(status, extra=extra).values():
             if re.search(regex, value['title'], re.I):
                 result.append(value)
         return result

--- a/mal/cli.py
+++ b/mal/cli.py
@@ -72,6 +72,8 @@ def create_parser():
                              choices=['all', 'watching', 'completed',
                                       'on hold', 'dropped',
                                       'plan to watch', 'rewatching'])
+    parser_list.add_argument('--extend', action='store_true', # defaults to False
+                             help='display extra info such as start/finish dates and tags')
     parser_list.set_defaults(func=commands.list)
 
     # Parser for "config" command

--- a/mal/commands.py
+++ b/mal/commands.py
@@ -45,7 +45,7 @@ def list(mal, args):
     if (args.section == 'all'):
         core.find(mal, '.+')
     else:
-        core.find(mal, '.+', args.section)
+        core.find(mal, '.+', args.section, args.extend)
 
 
 def config(mal, args):

--- a/mal/commands.py
+++ b/mal/commands.py
@@ -42,10 +42,7 @@ def list(mal, args):
     """Show all the animes on the users list."""
     # . matches any character except line breaks
     # + matches one or more occurences of the previous character
-    if (args.section == 'all'):
-        core.find(mal, '.+')
-    else:
-        core.find(mal, '.+', args.section, args.extend)
+    core.find(mal, '.+', args.section, args.extend)
 
 
 def config(mal, args):

--- a/mal/core.py
+++ b/mal/core.py
@@ -121,10 +121,11 @@ def anime_pprint(index, item, extra=False):
         'score': color.score_color(item['score']),
         'rewatching': (color.colorize(in_rewatching, 'yellow', 'bold'))
     }
+    # add formating options for extra info
     if extra:
         template.update({
-            'start': item['start_date'],
-            'finish': item['finish_date'],
+            'start': item['start_date'] if item['start_date'] != '0000-00-00' else 'NA',
+            'finish': item['finish_date'] if item['finish_date'] != '0000-00-00' else 'NA',
             'tags': item['tags']
         })
 

--- a/mal/core.py
+++ b/mal/core.py
@@ -84,9 +84,9 @@ def progress_update(mal, regex, inc):
         print(color.colorize("Failed with HTTP: {}".format(response), 'red'))
 
 
-def find(mal, regex, filtering='all'):
+def find(mal, regex, filtering='all', extra=False):
     """Find all anime in a certain status given a regex."""
-    items = mal.find(regex)
+    items = mal.find(regex, extra=extra)
     if len(items) == 0:
         print(color.colorize("No matches in list ᕙ(⇀‸↼‶)ᕗ", 'red'))
         return
@@ -101,10 +101,10 @@ def find(mal, regex, filtering='all'):
     # pretty print all the animes found
     sorted_items = sorted(items, key=itemgetter('status'), reverse=True)
     for index, item in enumerate(sorted_items):
-        anime_pprint(index + 1, item)
+        anime_pprint(index + 1, item, extra=extra)
 
 
-def anime_pprint(index, item):
+def anime_pprint(index, item, extra=False):
     """Pretty print an anime's information."""
     padding = int(math.log10(index)) + 3
     remaining_color = ('blue' if item['episode'] < item['total_episodes']
@@ -121,11 +121,24 @@ def anime_pprint(index, item):
         'score': color.score_color(item['score']),
         'rewatching': (color.colorize(in_rewatching, 'yellow', 'bold'))
     }
+    if extra:
+        template.update({
+            'start': item['start_date'],
+            'finish': item['finish_date'],
+            'tags': item['tags']
+        })
 
     message_lines = [
         "{index}: {title}".format_map(template),
         ("{padding}{status} at {remaining} episodes "
-         "with score {score} {rewatching}\n".format_map(template)),
+         "with score {score} {rewatching}".format_map(template))
     ]
 
-    print('\n'.join(message_lines))
+    # the extra information lines
+    if extra:
+        message_lines.extend([
+            "{padding}Started: {start} \t Finished: {finish}".format_map(template),
+            "{padding}Tags: {tags}".format_map(template)
+        ])
+
+    print('\n'.join(message_lines), "\n")


### PR DESCRIPTION
Added the `--extend` option and the funcionality. Decided to not color that part of the output, but that can be easily changed later. 
![mal](https://cloud.githubusercontent.com/assets/8689653/21994167/438087ac-dc16-11e6-88f9-c7a5f331b481.png)

The date show as NA if nothing was in the api call.

Relevant issue: #5 
