### PR TITLE
[api.py] Don't parse partial dates coming from mal - fix #65

### DIFF
--- a/mal/api.py
+++ b/mal/api.py
@@ -140,7 +140,7 @@ class MyAnimeList(object):
 
     def _fdate(self, date, api_format='%Y-%m-%d'):
         """Format date based on the user config format"""
-        if date == '0000-00-00':
+        if any(int(s) == 0 for s in date.split('-')):
             return date
         return datetime.strptime(date, api_format).strftime(self.date_format)
 


### PR DESCRIPTION
If any token which compose the date-string separated by '-' has a
zero-filled string, keep the date untouched.