### PR TITLE
Make mal.api.MyAnimeList more useful on REPL

### DIFF
--- a/mal/api.py
+++ b/mal/api.py
@@ -40,10 +40,10 @@ class MyAnimeList(object):
     # reverse of status_names dict
     status_codes = {v: k for k, v in status_names.items()}
 
-    def __init__(self, config):
-        self.username = config[setup.LOGIN_SECTION]['username']
-        self.password = config[setup.LOGIN_SECTION]['password']
-        self.date_format = config[setup.CONFIG_SECTION]['date_format']
+    def __init__(self, username, password, date_format=setup.DEFAULT_DATE_FORMAT):
+        self.username = username
+        self.password = password
+        self.date_format = date_format
 
     @checked_connection
     @animated('validating login')
@@ -59,7 +59,11 @@ class MyAnimeList(object):
     @classmethod
     def login(cls, config):
         """Create an instante of MyAnimeList and log it in."""
-        mal = cls(config)  # start instance of MyAnimeList
+        username = config[setup.LOGIN_SECTION]['username']
+        password = config[setup.LOGIN_SECTION]['password']
+        date_format = config[setup.CONFIG_SECTION]['date_format']
+
+        mal = cls(username, password, date_format)
 
         # 401 = unauthorized
         if mal.validate_login() == 401:

--- a/mal/setup.py
+++ b/mal/setup.py
@@ -25,9 +25,10 @@ APP_DIR = user_config_dir(APP_NAME)
 CONFIG_PATH = path.join(APP_DIR, APP_FILE)
 LOGIN_SECTION = 'login'
 CONFIG_SECTION = 'config'
+DEFAULT_DATE_FORMAT = "%Y-%m-%d"
 DEFAULT_CONFIG = {
     CONFIG_SECTION: {
-        'date_format': '%Y-%m-%d',
+        'date_format': DEFAULT_DATE_FORMAT,
         'animation': True,
     },
 }

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -10,10 +10,11 @@
 
 import unittest
 import sys
-import os
+from os.path import dirname
 
-sys.path.insert(0, os.path.dirname(__file__))
+__base__ = dirname(__file__)
+sys.path.insert(0, dirname(__base__))
 
-tests = unittest.defaultTestLoader.discover(__file__)
+tests = unittest.defaultTestLoader.discover(__base__)
 suite = unittest.defaultTestLoader.suiteClass(tests)
 unittest.TextTestRunner(verbosity=2).run(suite)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,3 @@
-
 import unittest
 from unittest import mock
 from unittest.mock import ANY
@@ -43,7 +42,7 @@ class TestApiList(unittest.TestCase):
             'my_score': 3,
             'series_episodes': 2,
             'my_rewatching': 1})
-      
+
         mock_requests_get.return_value = mock.Mock(
             text=list.get_response_xml())
         result = self.mal.list()
@@ -76,7 +75,7 @@ class TestApiList(unittest.TestCase):
             'my_finish_date': '2016-01-01',
             'my_tags': 'moe'
         })
-      
+
         mock_requests_get.return_value = mock.Mock(
             text=list.get_response_xml())
         result = self.mal.list(extra=True)
@@ -112,14 +111,14 @@ class TestApiList(unittest.TestCase):
             'series_animedb_id': 3,
             'series_title': 'anime3',
         })
-      
+
         mock_requests_get.return_value = mock.Mock(
             text=list.get_response_xml())
         result = self.mal.list(stats=True)
 
         self.assertTrue(3 in result)
         anime = result[3]
-        
+
         self.assertTrue('stats' in result)
         anime_stats_props_valid = lambda x: all(
             result['stats'].get(k) == v for k, v in x.items())
@@ -156,7 +155,7 @@ class TestApiFind(unittest.TestCase):
             'series_animedb_id': 2,
             'series_title': 'lost_anime'
         })
-       
+
         mock_requests_get.return_value = mock.Mock(
             text=list.get_response_xml())
         results = self.mal.find('found_anime')
@@ -177,7 +176,7 @@ class TestApiFind(unittest.TestCase):
             'series_animedb_id': 2,
             'series_title': 'found_anime2'
         })
-       
+
         mock_requests_get.return_value = mock.Mock(
             text=list.get_response_xml())
         results = self.mal.find('found_anime')
@@ -211,7 +210,7 @@ class TestApiValidateLogin(unittest.TestCase):
 
     @mock.patch.object(requests, 'get')
     def test_validate_login(self, mock_requests_get):
-        mal = api.MyAnimeList(MOCK_CONFIG)
+        mal = api.MyAnimeList.login(MOCK_CONFIG)
         mock_status_code = 1
         mock_requests_get.return_value = mock.Mock(
             status_code=mock_status_code)
@@ -315,7 +314,7 @@ class TestApiUpdate(unittest.TestCase):
             status_code=expected_response_code
         )
         result = self.mal.update(item_id, entry)
-        
+
         mock_requests_post.assert_called_with(
             'https://myanimelist.net/api/animelist/update/{0}.xml'.format(
                 item_id),


### PR DESCRIPTION
Make mal.api more easy to use on REPL

Now we can just call:

m = mal.api.MyAnimeList("<username>", "<password>")

Without dependent all the terrible config dict-like thing stuff.