### PR TITLE
[cli] translate anime_regex to anime_title on search command

### DIFF
--- a/mal/cli.py
+++ b/mal/cli.py
@@ -38,9 +38,9 @@ def create_parser():
 
     # Parser for "search" command
     parser_search = subparsers.add_parser('search',
-                                          help='search an anime')
-    parser_search.add_argument('anime_regex',
-                               help='regex pattern to match anime titles')
+                                          help='search an anime globally on MAL')
+    parser_search.add_argument('anime_title',
+                               help='a substring to match anime titles')
     parser_search.add_argument('--extend', action='store_true', # defaults to false
                                help='display all available information on anime')
     parser_search.set_defaults(func=commands.search)


### PR DESCRIPTION
This would avoid confusion since global search command doesn't use
regex at all! This just happened because the old search command
was renamed to filter, which use regex to match on the local
userlist.

Since we search is done by the REST API of mal, and I don't have
intention to do horrible web scrap stuff on something like mal,
this is the thing.

Being explicit it's important, sorry for the users that though
that would be possible search GLOBALLY for animes on MyAnimeList.
This will not gonna happen.

Closes #88