### PR TITLE
Update semantic versioning to alpha

### DIFF
--- a/mal/__init__.py
+++ b/mal/__init__.py
@@ -7,7 +7,7 @@
 #
 #
 
-__version__ = '0.4.0'
+__version__ = '0.4.0a0'
 __author__ = 'Manoel Vilela'
 __email__ = 'manoel_vilela@engineer.com'
 __url__ = 'https://github.com/ryukinix/mal'


### PR DESCRIPTION
Yes, this is a not a quite official release yet, we miss a little the
dev branch on the repo, but since we are merging features directly on
master we need at least tag official releases as not oficial relases,
alfa, beta, gama, iota, lambda, (okay, i'm overreacting a little) rc
stuff.

If you want see some decisions about that, take a look at this
nice discussion on a new comer contributor with some ideas
helping the repo: #90

We should take a more serious versioning style after this. Probably
incrementing the alfa/beta/rc versioning after some PR, and since
MINOR version was released, always tagging the PATCH as well after
release (as we already does it).

I think PATCH version should increase only after a match version of
MAJOR.MINOR was released, otherwise, alfa/beta/rc increment.

I think we can add that type of style on our CONTRIBUTING.md to being
more explicitly about that. Newcomers helping on that type of
documentation would be welcome. I really only have time on the
weekends.

That's all.